### PR TITLE
[dev] Update Cargo.toml features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ snowflaker = { version = "0.3", features = ["dynamic"] }
 
 [features]
 # For tests
-default = ["usetoml"]
+#default = ["usetoml"]
 usetoml = ["toml"]
 
 # https://docs.rs/about/metadata


### PR DESCRIPTION
-  Comment out the default feature `usetoml` that only use it in testing.